### PR TITLE
Upgrade openapi-rest-api lib to 0.1.4

### DIFF
--- a/.github/workflows/deploy-cdk-api.yml
+++ b/.github/workflows/deploy-cdk-api.yml
@@ -62,4 +62,5 @@ jobs:
         run: npm run deploy -- --require-approval never
         env:
           CREATE_CNAME_RECORD: true
+          OPENAPI_REST_API_REPORT_SUMMARY: true
         working-directory: ./api

--- a/api/package.json
+++ b/api/package.json
@@ -39,7 +39,7 @@
     "@aws-sdk/client-ecr": "^3.229.0",
     "@aws-sdk/client-s3": "^3.180.0",
     "@aws-sdk/lib-dynamodb": "^3.234.0",
-    "@connected-web/openapi-rest-api": "^0.1.3",
+    "@connected-web/openapi-rest-api": "^0.1.4",
     "ajv": "^8.12.0",
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@aws-sdk/client-ecr": "^3.229.0",
         "@aws-sdk/client-s3": "^3.180.0",
         "@aws-sdk/lib-dynamodb": "^3.234.0",
-        "@connected-web/openapi-rest-api": "^0.1.3",
+        "@connected-web/openapi-rest-api": "^0.1.4",
         "ajv": "^8.12.0",
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^2.1.1",
@@ -1573,12 +1573,9 @@
       "license": "MIT"
     },
     "node_modules/@connected-web/openapi-rest-api": {
-      "version": "0.1.3",
-      "license": "ISC",
-      "workspaces": [
-        "library",
-        "examples"
-      ]
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@connected-web/openapi-rest-api/-/openapi-rest-api-0.1.4.tgz",
+      "integrity": "sha512-c7vx+zo03fse1iCtuSK8vVAqzgEeJEUlUQ+uiV987KrhTmRarN7bujdNvhGfBwQH6nLEGD4DwSr/PCCQsuAWTQ=="
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -9270,6 +9267,7 @@
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -11945,6 +11943,7 @@
     },
     "node_modules/semver": {
       "version": "7.5.4",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -13471,6 +13470,7 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {


### PR DESCRIPTION
- Upgrade openapi-rest-api lib to 0.1.4
- Avoid double report summaries from tests duplicating those of the deployment.