### PR TITLE
Expose consumer API outputs and validate them post-deploy

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -128,6 +128,7 @@ jobs:
             }
             + (if ($hostedZoneId | length) > 0 then { HostedZoneId: $hostedZoneId } else {} end)')"
           echo "DEPLOY_CONFIG=$DEPLOY_CONFIG_JSON" >> "$GITHUB_ENV"
+          echo "DEPLOY_BASE_URL=https://${TARGET_INSTANCE_ID}.${HOSTED_ZONE_DOMAIN}" >> "$GITHUB_ENV"
 
       - name: Pack template-api package
         run: cweb -p "$TARGET_PROFILE" --user-pool-id "$USER_POOL_ID" package pack --component template-api --version "$PACKAGE_VERSION"
@@ -152,7 +153,44 @@ jobs:
             exit 1
           fi
 
+          echo "DEPLOY_ITEM_ID=$DEPLOY_ITEM_ID" >> "$GITHUB_ENV"
           cweb -p "$TARGET_PROFILE" deployments watch --item-id "$DEPLOY_ITEM_ID"
+
+      - name: Validate deployment outputs from Management API
+        run: |
+          set -euo pipefail
+
+          DEPLOYMENT_JSON="$(cweb -p "$TARGET_PROFILE" deployments describe --item-id "$DEPLOY_ITEM_ID")"
+          echo "$DEPLOYMENT_JSON"
+
+          EXPECTED_BASE_URL="$DEPLOY_BASE_URL"
+          EXPECTED_OPENAPI_URL="${EXPECTED_BASE_URL}/openapi"
+          EXPECTED_STATUS_URL="${EXPECTED_BASE_URL}/status"
+
+          ACTUAL_BASE_URL="$(jq -r '.deployment.outputs.ApiBaseUrl // empty' <<<"$DEPLOYMENT_JSON")"
+          ACTUAL_OPENAPI_URL="$(jq -r '.deployment.outputs.OpenAPISpecEndpoint // empty' <<<"$DEPLOYMENT_JSON")"
+          ACTUAL_STATUS_URL="$(jq -r '.deployment.outputs.StatusEndpoint // empty' <<<"$DEPLOYMENT_JSON")"
+          ACTUAL_GATEWAY_URL="$(jq -r '.deployment.outputs.ApiGatewayEndpoint // empty' <<<"$DEPLOYMENT_JSON")"
+
+          if [ "$ACTUAL_BASE_URL" != "$EXPECTED_BASE_URL" ]; then
+            echo "ApiBaseUrl mismatch: expected '$EXPECTED_BASE_URL', got '$ACTUAL_BASE_URL'" >&2
+            exit 1
+          fi
+
+          if [ "$ACTUAL_OPENAPI_URL" != "$EXPECTED_OPENAPI_URL" ]; then
+            echo "OpenAPISpecEndpoint mismatch: expected '$EXPECTED_OPENAPI_URL', got '$ACTUAL_OPENAPI_URL'" >&2
+            exit 1
+          fi
+
+          if [ "$ACTUAL_STATUS_URL" != "$EXPECTED_STATUS_URL" ]; then
+            echo "StatusEndpoint mismatch: expected '$EXPECTED_STATUS_URL', got '$ACTUAL_STATUS_URL'" >&2
+            exit 1
+          fi
+
+          if [ -z "$ACTUAL_GATEWAY_URL" ]; then
+            echo "ApiGatewayEndpoint output is empty" >&2
+            exit 1
+          fi
 
   post-deployment-tests:
     name: Post-deployment Tests for API


### PR DESCRIPTION
## Summary

Adds consumer-focused stack outputs for Template API and validates them in CI after remote package deployment.

## Why

Management UI currently highlights execute-api URL by default. We want consumers to focus on custom domain endpoints:

- ApiBaseUrl
- OpenAPISpecEndpoint
- StatusEndpoint

## Changes

- `api/src/ApiStack.ts`
  - Added outputs:
    - `ApiBaseUrl`
    - `OpenAPISpecEndpoint`
    - `StatusEndpoint`
    - `ApiGatewayEndpoint` (debug)
- `.github/workflows/pr-check.yml`
  - After `cweb package deploy` + `deployments watch`, call:
    - `cweb deployments describe --item-id <...>`
  - Assert `deployment.outputs` values match expected custom-domain URLs.

## Management API / cweb integration note

This uses the existing management deployment describe path surfaced by:

- `cweb deployments describe --item-id ...`

which maps to Management API `getDeployment` and returns `deployment.outputs`.

## Expected behavior

PR CI now fails if deployed output values drift from expected domain URLs, so we get explicit verification that the runtime context shown to consumers is correct.


## Verified Deployment Outputs

Captured from deployment `deployment.outputs` in CI/Management API:

```json
{
  "ApiBaseUrl": "https://template-api.dev.connected-web.services",
  "ApiGatewayEndpoint": "https://fjz4ly4l5h.execute-api.eu-west-2.amazonaws.com/v1/",
  "OpenAPISpecEndpoint": "https://template-api.dev.connected-web.services/openapi",
  "TemplateAPIEndpoint0377A7F7": "https://fjz4ly4l5h.execute-api.eu-west-2.amazonaws.com/v1/",
  "StatusEndpoint": "https://template-api.dev.connected-web.services/status"
}
```

`TemplateAPIEndpoint0377A7F7` is the legacy CDK-generated output; the consumer-facing outputs are `ApiBaseUrl`, `OpenAPISpecEndpoint`, and `StatusEndpoint`.
