### PR TITLE
ci: pass CWEB_CLIENT_TYPE into cweb machine-auth workflows

### DIFF
--- a/.github/workflows/package-pre-release.yml
+++ b/.github/workflows/package-pre-release.yml
@@ -38,6 +38,7 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.CONNECTED_WEB_PACKAGES_TOKEN }}
       CWEB_CLIENT_ID: ${{ secrets.CWEB_CLIENT_ID }}
       CWEB_CLIENT_SECRET: ${{ secrets.CWEB_CLIENT_SECRET }}
+      CWEB_CLIENT_TYPE: ${{ secrets.CWEB_CLIENT_TYPE }}
       CWEB_ACCOUNTS_DIR: ${{ github.workspace }}/.github/workflows/accounts
 
     steps:

--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -42,6 +42,7 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.CONNECTED_WEB_PACKAGES_TOKEN }}
       CWEB_CLIENT_ID: ${{ secrets.CWEB_CLIENT_ID }}
       CWEB_CLIENT_SECRET: ${{ secrets.CWEB_CLIENT_SECRET }}
+      CWEB_CLIENT_TYPE: ${{ secrets.CWEB_CLIENT_TYPE }}
       CWEB_ACCOUNTS_DIR: ${{ github.workspace }}/.github/workflows/accounts
 
     steps:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -221,6 +221,7 @@ jobs:
   publish-npm-client:
     name: Publish NPM Client
     needs: ['post-deployment-tests']
+    if: ${{ secrets.CWEB_CLIENT_TYPE == '' || startsWith(secrets.CWEB_CLIENT_TYPE, 'Cognito/') }}
     uses: ./.github/workflows/publish-npm-client.yml
     with:
       environment-name: dev

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -39,6 +39,7 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.CONNECTED_WEB_PACKAGES_TOKEN }}
       CWEB_CLIENT_ID: ${{ secrets.CWEB_CLIENT_ID }}
       CWEB_CLIENT_SECRET: ${{ secrets.CWEB_CLIENT_SECRET }}
+      CWEB_CLIENT_TYPE: ${{ secrets.CWEB_CLIENT_TYPE }}
       CWEB_ACCOUNTS_DIR: ${{ github.workspace }}/.github/workflows/accounts
       TARGET_ACCOUNT: connected-web-dev
       TARGET_PROFILE: dev
@@ -64,8 +65,8 @@ jobs:
       - name: Verify machine credentials are configured
         run: |
           set -euo pipefail
-          if [ -z "${CWEB_CLIENT_ID:-}" ] || [ -z "${CWEB_CLIENT_SECRET:-}" ]; then
-            echo "Missing CWEB_CLIENT_ID/CWEB_CLIENT_SECRET for CI machine login." >&2
+          if [ -z "${CWEB_CLIENT_ID:-}" ] || [ -z "${CWEB_CLIENT_SECRET:-}" ] || [ -z "${CWEB_CLIENT_TYPE:-}" ]; then
+            echo "Missing CWEB_CLIENT_ID/CWEB_CLIENT_SECRET/CWEB_CLIENT_TYPE for CI machine login." >&2
             echo "Bootstrap once from an operator workstation, then set GitHub secrets." >&2
             echo "Example: cweb repo bootstrap -p dev --org connected-web --repo template-api --env dev" >&2
             exit 1

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -221,7 +221,6 @@ jobs:
   publish-npm-client:
     name: Publish NPM Client
     needs: ['post-deployment-tests']
-    if: ${{ secrets.CWEB_CLIENT_TYPE == '' || startsWith(secrets.CWEB_CLIENT_TYPE, 'Cognito/') }}
     uses: ./.github/workflows/publish-npm-client.yml
     with:
       environment-name: dev

--- a/.github/workflows/publish-npm-client.yml
+++ b/.github/workflows/publish-npm-client.yml
@@ -34,7 +34,7 @@ jobs:
       CWEB_CLIENT_ID: ${{ secrets.CWEB_CLIENT_ID }}
       CWEB_CLIENT_SECRET: ${{ secrets.CWEB_CLIENT_SECRET }}
       CWEB_ACCOUNTS_DIR: ${{ github.workspace }}/.github/workflows/accounts
-      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NODE_AUTH_TOKEN: ${{ secrets.CONNECTED_WEB_PACKAGES_TOKEN != '' && secrets.CONNECTED_WEB_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -88,6 +88,14 @@ jobs:
           esac
 
       - name: Install cweb CLI
+        if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22.x
+          registry-url: https://npm.pkg.github.com
+          scope: '@connected-web'
+
+      - name: Install cweb CLI package
         if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}
         run: npm install -g @connected-web/cweb@latest --registry https://npm.pkg.github.com
 

--- a/.github/workflows/publish-npm-client.yml
+++ b/.github/workflows/publish-npm-client.yml
@@ -29,6 +29,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment-name || 'dev' }}
+    env:
+      CWEB_CLIENT_TYPE: ${{ secrets.CWEB_CLIENT_TYPE }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -54,7 +56,21 @@ jobs:
           fi
         shell: bash
 
+      - name: Check auth mode compatibility for API client publish
+        id: auth_mode
+        run: |
+          set -euo pipefail
+          CLIENT_TYPE="${CWEB_CLIENT_TYPE:-}"
+          if [ -z "$CLIENT_TYPE" ] || [[ "$CLIENT_TYPE" == Cognito/* ]]; then
+            echo "publish_client=true" >> "$GITHUB_OUTPUT"
+            echo "Using OAuth token endpoint mode for OpenAPI client publish."
+          else
+            echo "publish_client=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Skipping API client publish because CWEB_CLIENT_TYPE=$CLIENT_TYPE (non-Cognito machine auth)."
+          fi
+
       - name: Publish API Client
+        if: ${{ steps.auth_mode.outputs.publish_client == 'true' }}
         uses: connected-web/pnpfos@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-npm-client.yml
+++ b/.github/workflows/publish-npm-client.yml
@@ -31,6 +31,9 @@ jobs:
     environment: ${{ inputs.environment-name || 'dev' }}
     env:
       CWEB_CLIENT_TYPE: ${{ secrets.CWEB_CLIENT_TYPE }}
+      CWEB_CLIENT_ID: ${{ secrets.CWEB_CLIENT_ID }}
+      CWEB_CLIENT_SECRET: ${{ secrets.CWEB_CLIENT_SECRET }}
+      CWEB_ACCOUNTS_DIR: ${{ github.workspace }}/.github/workflows/accounts
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -62,15 +65,42 @@ jobs:
           set -euo pipefail
           CLIENT_TYPE="${CWEB_CLIENT_TYPE:-}"
           if [ -z "$CLIENT_TYPE" ] || [[ "$CLIENT_TYPE" == Cognito/* ]]; then
-            echo "publish_client=true" >> "$GITHUB_OUTPUT"
-            echo "Using OAuth token endpoint mode for OpenAPI client publish."
+            echo "mode=cognito" >> "$GITHUB_OUTPUT"
+            echo "Using OAuth token endpoint mode for OpenAPI client publish (${CLIENT_TYPE:-Cognito/AppClient/unknown})."
           else
-            echo "publish_client=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Skipping API client publish because CWEB_CLIENT_TYPE=$CLIENT_TYPE (non-Cognito machine auth)."
+            echo "mode=shared-authoriser" >> "$GITHUB_OUTPUT"
+            echo "Using cweb machine-auth mode for OpenAPI client publish ($CLIENT_TYPE)."
           fi
 
-      - name: Publish API Client
-        if: ${{ steps.auth_mode.outputs.publish_client == 'true' }}
+      - name: Resolve cweb profile from environment
+        if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}
+        id: cweb_profile
+        run: |
+          set -euo pipefail
+          case "${{ inputs.environment-name || 'dev' }}" in
+            dev) echo "profile=dev" >> "$GITHUB_OUTPUT" ;;
+            prod) echo "profile=prod" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "Unsupported environment-name for cweb profile mapping: ${{ inputs.environment-name || 'dev' }}" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Install cweb CLI
+        if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}
+        run: npm install -g @connected-web/cweb@latest
+
+      - name: Download OpenAPI spec via cweb machine auth
+        if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}
+        run: |
+          set -euo pipefail
+          mkdir -p .tmp
+          cweb -p "${{ steps.cweb_profile.outputs.profile }}" configure --write-github-env
+          cweb -p "${{ steps.cweb_profile.outputs.profile }}" curl "${{ inputs.openapi-spec-url || 'https://template-api.dev.connected-web.services/openapi' }}" --silent > .tmp/openapi.json
+          test -s .tmp/openapi.json
+
+      - name: Publish API Client (OAuth URL mode)
+        if: ${{ steps.auth_mode.outputs.mode == 'cognito' }}
         uses: connected-web/pnpfos@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -78,6 +108,14 @@ jobs:
           client-secret: ${{ secrets.CWEB_CLIENT_SECRET }}
           oauth-token-endpoint: ${{ inputs.oauth-token-endpoint || 'https://connected-web-dev.auth.eu-west-2.amazoncognito.com/oauth2/token' }}
           package-id: '@connected-web/template-api-client'
-          # openapi-spec-file: 'src/post-deployment/openapi-spec.json'
           openapi-spec-url: ${{ inputs.openapi-spec-url || 'https://template-api.dev.connected-web.services/openapi' }}
+          version: ${{ steps.version.outputs.version }}
+
+      - name: Publish API Client (Shared Authoriser mode)
+        if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}
+        uses: connected-web/pnpfos@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          package-id: '@connected-web/template-api-client'
+          openapi-spec-file: '.tmp/openapi.json'
           version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-npm-client.yml
+++ b/.github/workflows/publish-npm-client.yml
@@ -34,6 +34,7 @@ jobs:
       CWEB_CLIENT_ID: ${{ secrets.CWEB_CLIENT_ID }}
       CWEB_CLIENT_SECRET: ${{ secrets.CWEB_CLIENT_SECRET }}
       CWEB_ACCOUNTS_DIR: ${{ github.workspace }}/.github/workflows/accounts
+      NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -88,7 +89,7 @@ jobs:
 
       - name: Install cweb CLI
         if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}
-        run: npm install -g @connected-web/cweb@latest
+        run: npm install -g @connected-web/cweb@latest --registry https://npm.pkg.github.com
 
       - name: Download OpenAPI spec via cweb machine auth
         if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}

--- a/.github/workflows/publish-npm-client.yml
+++ b/.github/workflows/publish-npm-client.yml
@@ -78,7 +78,7 @@ jobs:
           set -euo pipefail
           test -n "${CWEB_CLIENT_ID:-}"
           test -n "${CWEB_CLIENT_SECRET:-}"
-          mkdir -p .tmp
+          OPENAPI_FILE="/tmp/template-api-openapi.json"
           AUTH_HEADER="$(node - <<'NODE'
           const crypto = require('crypto')
           const clientId = process.env.CWEB_CLIENT_ID || ''
@@ -92,8 +92,8 @@ jobs:
           )"
           curl --fail --silent --show-error \
             -H "Authorization: ${AUTH_HEADER}" \
-            "${{ inputs.openapi-spec-url || 'https://template-api.dev.connected-web.services/openapi' }}" > .tmp/openapi.json
-          test -s .tmp/openapi.json
+            "${{ inputs.openapi-spec-url || 'https://template-api.dev.connected-web.services/openapi' }}" > "$OPENAPI_FILE"
+          test -s "$OPENAPI_FILE"
 
       - name: Publish API Client (OAuth URL mode)
         if: ${{ steps.auth_mode.outputs.mode == 'cognito' }}
@@ -113,5 +113,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           package-id: '@connected-web/template-api-client'
-          openapi-spec-file: '.tmp/openapi.json'
+          openapi-spec-file: '/tmp/template-api-openapi.json'
           version: ${{ steps.version.outputs.version }}

--- a/.github/workflows/publish-npm-client.yml
+++ b/.github/workflows/publish-npm-client.yml
@@ -33,7 +33,6 @@ jobs:
       CWEB_CLIENT_TYPE: ${{ secrets.CWEB_CLIENT_TYPE }}
       CWEB_CLIENT_ID: ${{ secrets.CWEB_CLIENT_ID }}
       CWEB_CLIENT_SECRET: ${{ secrets.CWEB_CLIENT_SECRET }}
-      CWEB_ACCOUNTS_DIR: ${{ github.workspace }}/.github/workflows/accounts
       NODE_AUTH_TOKEN: ${{ secrets.CONNECTED_WEB_PACKAGES_TOKEN != '' && secrets.CONNECTED_WEB_PACKAGES_TOKEN || secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
@@ -73,39 +72,27 @@ jobs:
             echo "Using cweb machine-auth mode for OpenAPI client publish ($CLIENT_TYPE)."
           fi
 
-      - name: Resolve cweb profile from environment
-        if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}
-        id: cweb_profile
-        run: |
-          set -euo pipefail
-          case "${{ inputs.environment-name || 'dev' }}" in
-            dev) echo "profile=dev" >> "$GITHUB_OUTPUT" ;;
-            prod) echo "profile=prod" >> "$GITHUB_OUTPUT" ;;
-            *)
-              echo "Unsupported environment-name for cweb profile mapping: ${{ inputs.environment-name || 'dev' }}" >&2
-              exit 1
-              ;;
-          esac
-
-      - name: Install cweb CLI
-        if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22.x
-          registry-url: https://npm.pkg.github.com
-          scope: '@connected-web'
-
-      - name: Install cweb CLI package
-        if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}
-        run: npm install -g @connected-web/cweb@latest --registry https://npm.pkg.github.com
-
-      - name: Download OpenAPI spec via cweb machine auth
+      - name: Download OpenAPI spec via Shared Authoriser machine auth
         if: ${{ steps.auth_mode.outputs.mode == 'shared-authoriser' }}
         run: |
           set -euo pipefail
+          test -n "${CWEB_CLIENT_ID:-}"
+          test -n "${CWEB_CLIENT_SECRET:-}"
           mkdir -p .tmp
-          cweb -p "${{ steps.cweb_profile.outputs.profile }}" configure --write-github-env
-          cweb -p "${{ steps.cweb_profile.outputs.profile }}" curl "${{ inputs.openapi-spec-url || 'https://template-api.dev.connected-web.services/openapi' }}" --silent > .tmp/openapi.json
+          AUTH_HEADER="$(node - <<'NODE'
+          const crypto = require('crypto')
+          const clientId = process.env.CWEB_CLIENT_ID || ''
+          const clientSecret = process.env.CWEB_CLIENT_SECRET || ''
+          const windowValue = Math.floor(Date.now() / 1000 / 300)
+          const data = `${clientId}:${windowValue}`
+          const hmac = crypto.createHmac('sha256', clientSecret).update(data).digest('hex')
+          const token = Buffer.from(`${data}:${hmac}`).toString('base64')
+          process.stdout.write(`CWEB ${token}`)
+          NODE
+          )"
+          curl --fail --silent --show-error \
+            -H "Authorization: ${AUTH_HEADER}" \
+            "${{ inputs.openapi-spec-url || 'https://template-api.dev.connected-web.services/openapi' }}" > .tmp/openapi.json
           test -s .tmp/openapi.json
 
       - name: Publish API Client (OAuth URL mode)


### PR DESCRIPTION
## Summary
- pass `CWEB_CLIENT_TYPE` from GitHub environment secrets into workflow job env
- update machine-auth preflight check to require `CWEB_CLIENT_TYPE` alongside `CWEB_CLIENT_ID` and `CWEB_CLIENT_SECRET`
- align template-api CI with Shared Authoriser API-key mode detection in cweb

## Why
Recent release failures showed that when `CWEB_CLIENT_TYPE` is missing in job env, cweb falls back to legacy `Cognito/AppClient/unknown` mode and machine login can fail (`invalid_client`) even when new API-key credentials are configured.

## Checklist
- [x] `package-pre-release.yml` includes `CWEB_CLIENT_TYPE`
- [x] `package-release.yml` includes `CWEB_CLIENT_TYPE`
- [x] `pr-check.yml` includes `CWEB_CLIENT_TYPE`
- [x] preflight check message updated to mention all 3 required secrets
- [x] run `cweb repo bootstrap` for `dev` and `prod` and verify secrets are present in repo environments
- [x] confirm CI passes through `Login cweb machine identity`
